### PR TITLE
Fix Content Security Policy (CSP) errors

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -12,7 +12,7 @@
       name="description"
       content="Sudharsana Rajasekaran's Professional Portfolio - Data Engineer"
     />
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://fonts.gstatic.com; font-src 'self' https://fonts.gstatic.com; connect-src 'self' https://us-central1-sudhanportfoliowebsite.cloudfunctions.net;" />
     <!-- Apple Touch Icon for iOS devices -->
     <!-- Place your custom logo file (e.g., custom-logo.png) in the 'public/' folder -->
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/custom-logo.png" />


### PR DESCRIPTION
The existing CSP was too restrictive and blocked resources from external domains, causing errors in the browser console.

This change updates the CSP meta tag in `public/index.html` to:
- Allow stylesheets and fonts from `fonts.googleapis.com` and `fonts.gstatic.com`.
- Allow API connections to `us-central1-sudhanportfoliowebsite.cloudfunctions.net`.

This resolves the stylesheet and API request errors.