### PR TITLE
Feat: Add avatar to hero section

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -220,6 +220,19 @@ body {
     transform: scale(1.05);
 }
 
+.hero-avatar {
+  width: 150px;
+  height: 150px;
+  border-radius: 50%;
+  object-fit: cover;
+  margin-bottom: 1.5rem;
+  border: 4px solid var(--white);
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.2), 0 4px 6px -2px rgba(0, 0, 0, 0.1);
+  display: block;
+  margin-left: auto;
+  margin-right: auto;
+}
+
 /* Section Styling (General) */
 .section-padding {
     padding-top: 5rem; /* py-20 */

--- a/src/components/Hero.js
+++ b/src/components/Hero.js
@@ -8,6 +8,7 @@ const Hero = ({ scrollToSection }) => {
                 <div className="animate-pulse-slow delay-500" style={{ bottom: 0, right: 0 }}></div>
             </div>
             <div className="hero-content">
+                <img src="https://i.pravatar.cc/150" alt="Sudharsana Rajasekaran" className="hero-avatar" />
                 <h2 className="hero-title animate-fade-in-up">
                     Hello, I'm <span style={{ color: 'var(--yellow-300)' }}>Sudharsana Rajasekaran</span>
                 </h2>


### PR DESCRIPTION
- Adds a placeholder avatar image to the hero section, above the main heading.
- The avatar is styled as a small, circular image with a border and shadow.
- The image is sourced from a placeholder service, which can be replaced with a real image later.