### PR TITLE
feat: Increase avatar size and prevent cropping

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -221,10 +221,10 @@ body {
 }
 
 .hero-avatar {
-  width: 150px;
-  height: 150px;
+  width: 180px;
+  height: 180px;
   border-radius: 50%;
-  object-fit: cover;
+  object-fit: contain;
   margin-bottom: 1.5rem;
   border: 4px solid var(--white);
   box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.2), 0 4px 6px -2px rgba(0, 0, 0, 0.1);


### PR DESCRIPTION
Increases the size of the hero avatar from 150px to 180px. Changes the object-fit property from 'cover' to 'contain' to ensure the entire image is visible and the head is not cropped.